### PR TITLE
fix: prevents user from selecting start time in past

### DIFF
--- a/packages/client/src/views/EventDetailsForm.tsx
+++ b/packages/client/src/views/EventDetailsForm.tsx
@@ -213,12 +213,20 @@ export default function EventDetailsFormView() {
 
   const handleStartDateChange = (d: Date) => {
     let newEndTime = state.endTime;
-    if (d > newEndTime) {
+    let newStartTime = d;
+    if (newStartTime > newEndTime) {
       newEndTime = d;
+    }
+    let now = new Date();
+    if (newStartTime < now) {
+      newStartTime = now;
+      enqueueSnackbar("Start time cannot be in the past.", {
+        variant: "warning",
+      });
     }
     setState({
       ...state,
-      startTime: d,
+      startTime: newStartTime,
       endTime: newEndTime,
     });
   };


### PR DESCRIPTION
-if time selection is in past, resets it to current time and posts a snackbar warning